### PR TITLE
Adds a checking for a null value of attribute being parsed

### DIFF
--- a/lib/parser.js
+++ b/lib/parser.js
@@ -99,6 +99,7 @@ Parser.prototype.writeLong = function(value) {
 
 Parser.prototype.readString = function() {
   var length = this.readInt();
+  if (length < 0) return null;
   return this.buffer.toString('utf8', this.position, this.position += length);
 };
 Parser.prototype.writeString = function(value) {


### PR DESCRIPTION
If a column of type varchar has a null value for a particular row, the parser fails.