### PR TITLE
check for null object

### DIFF
--- a/lib/message.js
+++ b/lib/message.js
@@ -120,16 +120,11 @@ QueryMessage = function(buffer) {
     this.exception = this.readException(1);
     // seems size doesn't matter, always 1
   } else {
-    // don't parse the rest if there was an exception. Bad material there.
     var resultCount = this.readShort();
-    if(resultCount != 0)
-      resultCount = 1;
-    // there can be more than one table with rows
     this.table = new Array(resultCount);
     for(var i = 0; i < resultCount; i++) {
       this.table[i] = this.readVoltTable();
     }
-
   }
 }
 

--- a/lib/parser.js
+++ b/lib/parser.js
@@ -313,6 +313,10 @@ Parser.prototype.writeParameterSet = function(types, values) {
   for(var i = 0; i < length; i++) {
     var type = types[i];
     var value = values[i];
+
+    if(value === null)
+      type = 'null';
+
     checkType(type, value);
 
     // handle the array type

--- a/lib/parser.js
+++ b/lib/parser.js
@@ -99,6 +99,7 @@ Parser.prototype.writeLong = function(value) {
 
 Parser.prototype.readString = function() {
   var length = this.readInt();
+  if (length < 0) return null; // https://github.com/VoltDB/voltdb-client-nodejs/pull/8/files
   return this.buffer.toString('utf8', this.position, this.position += length);
 };
 Parser.prototype.writeString = function(value) {

--- a/lib/parser.js
+++ b/lib/parser.js
@@ -81,7 +81,9 @@ Parser.prototype.readLongBytes = function() {
 };
 
 Parser.prototype.readLong = function() {
-  return this.readLongBytes()[0];
+  // return this.readLongBytes()[0];
+  // https://github.com/VoltDB/voltdb-client-nodejs/issues/12
+  return this.readLongBytes().intValue();
 };
 Parser.prototype.writeLong = function(value) {
   var bytes, numBytes = 8;

--- a/lib/parser.js
+++ b/lib/parser.js
@@ -24,8 +24,8 @@
  * ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
  * OTHER DEALINGS IN THE SOFTWARE.
  */
-var BigInteger = require('bignumber').BigInteger, 
-ctype = require('./ctype'), 
+var BigInteger = require('bignumber').BigInteger,
+ctype = require('./ctype'),
 endian = 'big';
 
 function Parser(buffer) {
@@ -464,7 +464,7 @@ function checkType(type, value) {
   if( typeof value === 'string' && !STRING_TYPES[type])
     throw new Error('Providing a string type for a non-string field. ' + value + ' can not be a ' + type);
 
-  if( typeof value === 'object' && !( value instanceof Array))
+  if( typeof value === 'object' && value !== null && !( value instanceof Array))
     throw new Error('Cannot provide custom objects as procedure parameters');
 
   if( value instanceof Array && type.slice(0, 5) != 'array')

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "voltjs-alt",
     "description": "VoltDB binary driver - a workaround version",
-    "version": "0.2.0",
+    "version": "0.2.1",
     "author": "VoltDB",
     "engines": {
         "node": ">= 0.6.0"
@@ -10,7 +10,6 @@
         "type": "git",
         "url": "https://github.com/ypocat/voltdb-client-nodejs.git"
     },
-
     "dependencies": {
         "bignumber": "latest",
         "ctype": "latest",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "voltjs-alt",
     "description": "VoltDB binary driver - a workaround version",
-    "version": "0.2.1",
+    "version": "0.2.2",
     "author": "VoltDB",
     "engines": {
         "node": ">= 0.6.0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
-    "name": "voltjs",
-    "description": "VoltDB binary driver",
+    "name": "voltjs-alt",
+    "description": "VoltDB binary driver - a workaround version",
     "version": "0.2.0",
     "author": "VoltDB",
     "engines": {
@@ -8,7 +8,7 @@
     },
     "repository": {
         "type": "git",
-        "url": "https://github.com/VoltDB/voltdb-client-nodejs.git"
+        "url": "https://github.com/ypocat/voltdb-client-nodejs.git"
     },
 
     "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "voltjs-alt",
     "description": "VoltDB binary driver - a workaround version",
-    "version": "0.2.2",
+    "version": "0.2.3",
     "author": "VoltDB",
     "engines": {
         "node": ">= 0.6.0"


### PR DESCRIPTION
This fix makes it possible to pass NULL values to the auto-generated insert statement procedures. The field also has to be declared as `null` in the JS declaration of the procedure (instantiations of VoltQuery).
