### PR TITLE
Register to QUERY_RESPONSE_ERROR event when calling a procedure.

### DIFF
--- a/lib/connection.js
+++ b/lib/connection.js
@@ -116,6 +116,7 @@ VoltConnection.prototype.callProcedure = function(query, readCallback, writeCall
     
     if (readCallback) {
       vmm.on(VoltConstants.SESSION_EVENT.QUERY_RESPONSE, readCallback);
+      vmm.on(VoltConstants.SESSION_EVENT.QUERY_RESPONSE_ERROR, readCallback);
     }
     
     if ( writeCallback ) {


### PR DESCRIPTION
Hi, it seems that the callback is never called when the queries time out. Because in _checkQueryTimeout, vmm emits the QUERY_RESPONSE_ERROR event but no one is listening to it. Please check whether this is the right solution and accept the pull request.