### PR TITLE
Fixes for ENG-12689

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,5 @@
 node_modules
-
+tools/testdb/voltdbroot/
+tools/testdb/obj/
+tools/testdb/log/
+tools/testdb/typetest.jar

--- a/README.md
+++ b/README.md
@@ -1,11 +1,11 @@
-VoltDB NodeJS Wire Protocol Driver 1.1
-========================================
+VoltDB NodeJS Wire Protocol Driver 2.0
+======================================
 
 Requirements
 ============
 
-Node.js 0.9.1 or later
-VoltDB 2.8 or later
+Node.js 6.11.0 or later
+VoltDB 7.5 or later
 
 
 Installation

--- a/examples/voter/voter/views/index.jade
+++ b/examples/voter/voter/views/index.jade
@@ -16,7 +16,7 @@ table#VOTES
         tr: td
             td
  
-script
+script.
     $(function() {
         setInterval(getVotes, 400);
     });

--- a/examples/voter/voter/views/layout.jade
+++ b/examples/voter/voter/views/layout.jade
@@ -1,4 +1,4 @@
-!!!
+doctype
 html
   head
     title= title

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,1751 @@
+{
+    "name": "voltjs",
+    "version": "1.1.0",
+    "lockfileVersion": 1,
+    "dependencies": {
+        "ansi-regex": {
+            "version": "2.1.1",
+            "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
+            "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8="
+        },
+        "ansi-styles": {
+            "version": "2.2.1",
+            "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
+            "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4="
+        },
+        "argparse": {
+            "version": "1.0.9",
+            "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.9.tgz",
+            "integrity": "sha1-c9g7wmP4bpf4zE9rrhsOkKfSLIY="
+        },
+        "asn1": {
+            "version": "0.2.3",
+            "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.3.tgz",
+            "integrity": "sha1-2sh4dxPJlmhJ/IGAd36+nB3fO4Y="
+        },
+        "assert-plus": {
+            "version": "0.2.0",
+            "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.2.0.tgz",
+            "integrity": "sha1-104bh+ev/A24qttwIfP+SBAasjQ="
+        },
+        "asynckit": {
+            "version": "0.4.0",
+            "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+            "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k="
+        },
+        "aws-sign2": {
+            "version": "0.6.0",
+            "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.6.0.tgz",
+            "integrity": "sha1-FDQt0428yU0OW4fXY81jYSwOeU8="
+        },
+        "aws4": {
+            "version": "1.6.0",
+            "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.6.0.tgz",
+            "integrity": "sha1-g+9cqGCysy5KDe7e6MdxudtXRx4="
+        },
+        "balanced-match": {
+            "version": "0.4.2",
+            "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.4.2.tgz",
+            "integrity": "sha1-yz8+PHMtwPAe5wtAPzAuYddwmDg="
+        },
+        "bcrypt-pbkdf": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.1.tgz",
+            "integrity": "sha1-Y7xdy2EzG5K8Bf1SiVPDNGKgb40=",
+            "optional": true
+        },
+        "bignumber": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/bignumber/-/bignumber-1.1.0.tgz",
+            "integrity": "sha1-5qsKdD2l8+oBjlwXWX0SH3howVk="
+        },
+        "bind-obj-methods": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/bind-obj-methods/-/bind-obj-methods-1.0.0.tgz",
+            "integrity": "sha1-T1l5ysFXk633DkiBYeRj4gnKUJw="
+        },
+        "bluebird": {
+            "version": "3.5.0",
+            "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.5.0.tgz",
+            "integrity": "sha1-eRQg1/VR7qKJdFOop3ZT+WYG1nw="
+        },
+        "boom": {
+            "version": "2.10.1",
+            "resolved": "https://registry.npmjs.org/boom/-/boom-2.10.1.tgz",
+            "integrity": "sha1-OciRjO/1eZ+D+UkqhI9iWt0Mdm8="
+        },
+        "brace-expansion": {
+            "version": "1.1.7",
+            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.7.tgz",
+            "integrity": "sha1-Pv/DxQ4ABTH7cg6v+A8K6O8jz1k="
+        },
+        "caseless": {
+            "version": "0.11.0",
+            "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.11.0.tgz",
+            "integrity": "sha1-cVuW6phBWTzDMGeSP17GDr2k99c="
+        },
+        "chalk": {
+            "version": "1.1.3",
+            "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+            "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg="
+        },
+        "clean-yaml-object": {
+            "version": "0.1.0",
+            "resolved": "https://registry.npmjs.org/clean-yaml-object/-/clean-yaml-object-0.1.0.tgz",
+            "integrity": "sha1-Y/sRDcLOGoTcIfbZM0h20BCui2g="
+        },
+        "cli": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/cli/-/cli-1.0.1.tgz",
+            "integrity": "sha1-IoF1NPJL+klQw01TLUjsvGIbjBQ="
+        },
+        "color-support": {
+            "version": "1.1.3",
+            "resolved": "https://registry.npmjs.org/color-support/-/color-support-1.1.3.tgz",
+            "integrity": "sha512-qiBjkpbMLO/HL68y+lh4q0/O1MZFj2RX6X/KmMa3+gJD3z+WwI1ZzDHysvqHGS3mP6mznPckpXmw1nI9cJjyRg=="
+        },
+        "combined-stream": {
+            "version": "1.0.5",
+            "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.5.tgz",
+            "integrity": "sha1-k4NwpXtKUd6ix3wV1cX9+JUWQAk="
+        },
+        "commander": {
+            "version": "2.9.0",
+            "resolved": "https://registry.npmjs.org/commander/-/commander-2.9.0.tgz",
+            "integrity": "sha1-nJkJQXbhIkDLItbFFGCYQA/g99Q="
+        },
+        "concat-map": {
+            "version": "0.0.1",
+            "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+            "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
+        },
+        "core-util-is": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
+            "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac="
+        },
+        "coveralls": {
+            "version": "2.13.1",
+            "resolved": "https://registry.npmjs.org/coveralls/-/coveralls-2.13.1.tgz",
+            "integrity": "sha1-1wu5rMGDXsTwY/+drFQjwXsR8Xg=",
+            "dependencies": {
+                "js-yaml": {
+                    "version": "3.6.1",
+                    "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.6.1.tgz",
+                    "integrity": "sha1-bl/mfYsgXOTSL60Ft3geja3MSzA="
+                }
+            }
+        },
+        "cross-spawn": {
+            "version": "4.0.2",
+            "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-4.0.2.tgz",
+            "integrity": "sha1-e5JHYhwjrf3ThWAEqCPL45dCTUE="
+        },
+        "cryptiles": {
+            "version": "2.0.5",
+            "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-2.0.5.tgz",
+            "integrity": "sha1-O9/s3GCBR8HGcgL6KR59ylnqo7g="
+        },
+        "ctype": {
+            "version": "0.5.5",
+            "resolved": "https://registry.npmjs.org/ctype/-/ctype-0.5.5.tgz",
+            "integrity": "sha1-nzjF4eiYQOsfWXKQ0SKuKXJqVvs="
+        },
+        "dashdash": {
+            "version": "1.14.1",
+            "resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
+            "integrity": "sha1-hTz6D3y+L+1d4gMmuN1YEDX24vA=",
+            "dependencies": {
+                "assert-plus": {
+                    "version": "1.0.0",
+                    "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
+                    "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU="
+                }
+            }
+        },
+        "debug": {
+            "version": "2.6.8",
+            "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.8.tgz",
+            "integrity": "sha1-5zFTHKLt4n0YgiJCfaF4IdaP9Pw="
+        },
+        "deeper": {
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/deeper/-/deeper-2.1.0.tgz",
+            "integrity": "sha1-vFZOX3MXT98gHgiwADDooU2nQ2g="
+        },
+        "delayed-stream": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+            "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk="
+        },
+        "diff": {
+            "version": "1.4.0",
+            "resolved": "https://registry.npmjs.org/diff/-/diff-1.4.0.tgz",
+            "integrity": "sha1-fyjS657nsVqX79ic5j3P2qPMur8="
+        },
+        "ecc-jsbn": {
+            "version": "0.1.1",
+            "resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.1.tgz",
+            "integrity": "sha1-D8c6ntXw1Tw4GTOYUj735UN3dQU=",
+            "optional": true
+        },
+        "ejs": {
+            "version": "2.5.6",
+            "resolved": "https://registry.npmjs.org/ejs/-/ejs-2.5.6.tgz",
+            "integrity": "sha1-R5Y2v6P+Ox3r1SCH8KyyBLTxnIg="
+        },
+        "escape-string-regexp": {
+            "version": "1.0.5",
+            "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+            "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ="
+        },
+        "esprima": {
+            "version": "2.7.3",
+            "resolved": "https://registry.npmjs.org/esprima/-/esprima-2.7.3.tgz",
+            "integrity": "sha1-luO3DVd59q1JzQMmc9HDEnZ7pYE="
+        },
+        "events-to-array": {
+            "version": "1.1.2",
+            "resolved": "https://registry.npmjs.org/events-to-array/-/events-to-array-1.1.2.tgz",
+            "integrity": "sha1-LUH1Y+H+QA7Uli/hpNXGp1Od9/Y="
+        },
+        "exit": {
+            "version": "0.1.2",
+            "resolved": "https://registry.npmjs.org/exit/-/exit-0.1.2.tgz",
+            "integrity": "sha1-BjJjj42HfMghB9MKD/8aF8uhzQw="
+        },
+        "extend": {
+            "version": "3.0.1",
+            "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.1.tgz",
+            "integrity": "sha1-p1Xqe8Gt/MWjHOfnYtuq3F5jZEQ="
+        },
+        "extsprintf": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.0.2.tgz",
+            "integrity": "sha1-4QgOBljjALBilJkMxw4VAiNf1VA="
+        },
+        "foreground-child": {
+            "version": "1.5.6",
+            "resolved": "https://registry.npmjs.org/foreground-child/-/foreground-child-1.5.6.tgz",
+            "integrity": "sha1-T9ca0t/elnibmApcCilZN8svXOk="
+        },
+        "forever-agent": {
+            "version": "0.6.1",
+            "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz",
+            "integrity": "sha1-+8cfDEGt6zf5bFd60e1C2P2sypE="
+        },
+        "form-data": {
+            "version": "2.1.4",
+            "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.1.4.tgz",
+            "integrity": "sha1-M8GDrPGTJ27KqYFDpp6Uv+4XUNE="
+        },
+        "fs-exists-cached": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/fs-exists-cached/-/fs-exists-cached-1.0.0.tgz",
+            "integrity": "sha1-zyVVTKBQ3EmuZla0HeQiWJidy84="
+        },
+        "fs.realpath": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
+            "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8="
+        },
+        "function-loop": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/function-loop/-/function-loop-1.0.1.tgz",
+            "integrity": "sha1-gHa7MF6OajzO7ikgdl8zDRkPNAw="
+        },
+        "generate-function": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/generate-function/-/generate-function-2.0.0.tgz",
+            "integrity": "sha1-aFj+fAlpt9TpCTM3ZHrHn2DfvnQ="
+        },
+        "generate-object-property": {
+            "version": "1.2.0",
+            "resolved": "https://registry.npmjs.org/generate-object-property/-/generate-object-property-1.2.0.tgz",
+            "integrity": "sha1-nA4cQDCM6AT0eDYYuTf6iPmdUNA="
+        },
+        "getpass": {
+            "version": "0.1.7",
+            "resolved": "https://registry.npmjs.org/getpass/-/getpass-0.1.7.tgz",
+            "integrity": "sha1-Xv+OPmhNVprkyysSgmBOi6YhSfo=",
+            "dependencies": {
+                "assert-plus": {
+                    "version": "1.0.0",
+                    "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
+                    "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU="
+                }
+            }
+        },
+        "glob": {
+            "version": "7.1.2",
+            "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
+            "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ=="
+        },
+        "graceful-readlink": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/graceful-readlink/-/graceful-readlink-1.0.1.tgz",
+            "integrity": "sha1-TK+tdrxi8C+gObL5Tpo906ORpyU="
+        },
+        "har-validator": {
+            "version": "2.0.6",
+            "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-2.0.6.tgz",
+            "integrity": "sha1-zcvAgYgmWtEZtqWnyKtw7s+10n0="
+        },
+        "has-ansi": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
+            "integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE="
+        },
+        "hawk": {
+            "version": "3.1.3",
+            "resolved": "https://registry.npmjs.org/hawk/-/hawk-3.1.3.tgz",
+            "integrity": "sha1-B4REvXwWQLD+VA0sm3PVlnjo4cQ="
+        },
+        "hoek": {
+            "version": "2.16.3",
+            "resolved": "https://registry.npmjs.org/hoek/-/hoek-2.16.3.tgz",
+            "integrity": "sha1-ILt0A9POo5jpHcRxCo/xuCdKJe0="
+        },
+        "http-signature": {
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.1.1.tgz",
+            "integrity": "sha1-33LiZwZs0Kxn+3at+OE0qPvPkb8="
+        },
+        "inflight": {
+            "version": "1.0.6",
+            "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+            "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk="
+        },
+        "inherits": {
+            "version": "2.0.3",
+            "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+            "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4="
+        },
+        "is-my-json-valid": {
+            "version": "2.16.0",
+            "resolved": "https://registry.npmjs.org/is-my-json-valid/-/is-my-json-valid-2.16.0.tgz",
+            "integrity": "sha1-8Hndm/2uZe4gOKrorLyGqxCeNpM="
+        },
+        "is-property": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/is-property/-/is-property-1.0.2.tgz",
+            "integrity": "sha1-V/4cTkhHTt1lsJkR8msc1Ald2oQ="
+        },
+        "is-typedarray": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
+            "integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo="
+        },
+        "isarray": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+            "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
+        },
+        "isexe": {
+            "version": "1.1.2",
+            "resolved": "https://registry.npmjs.org/isexe/-/isexe-1.1.2.tgz",
+            "integrity": "sha1-NvPiLmB1CSD15yQaR2qMakInWtA="
+        },
+        "isstream": {
+            "version": "0.1.2",
+            "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
+            "integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo="
+        },
+        "js-yaml": {
+            "version": "3.8.4",
+            "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.8.4.tgz",
+            "integrity": "sha1-UgtFZPhlc7qWZir4Woyvp7S1pvY=",
+            "dependencies": {
+                "esprima": {
+                    "version": "3.1.3",
+                    "resolved": "https://registry.npmjs.org/esprima/-/esprima-3.1.3.tgz",
+                    "integrity": "sha1-/cpRzuYTOJXjyI1TXOSdv/YqRjM="
+                }
+            }
+        },
+        "jsbn": {
+            "version": "0.1.1",
+            "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.1.tgz",
+            "integrity": "sha1-peZUwuWi3rXyAdls77yoDA7y9RM=",
+            "optional": true
+        },
+        "json-schema": {
+            "version": "0.2.3",
+            "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.2.3.tgz",
+            "integrity": "sha1-tIDIkuWaLwWVTOcnvT8qTogvnhM="
+        },
+        "json-stringify-safe": {
+            "version": "5.0.1",
+            "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
+            "integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus="
+        },
+        "jsonpointer": {
+            "version": "4.0.1",
+            "resolved": "https://registry.npmjs.org/jsonpointer/-/jsonpointer-4.0.1.tgz",
+            "integrity": "sha1-T9kss04OnbPInIYi7PUfm5eMbLk="
+        },
+        "jsprim": {
+            "version": "1.4.0",
+            "resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.4.0.tgz",
+            "integrity": "sha1-o7h+QCmNjDgFUtjMdiigu5WiKRg=",
+            "dependencies": {
+                "assert-plus": {
+                    "version": "1.0.0",
+                    "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
+                    "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU="
+                }
+            }
+        },
+        "lcov-parse": {
+            "version": "0.0.10",
+            "resolved": "https://registry.npmjs.org/lcov-parse/-/lcov-parse-0.0.10.tgz",
+            "integrity": "sha1-GwuP+ayceIklBYK3C3ExXZ2m2aM="
+        },
+        "log-driver": {
+            "version": "1.2.5",
+            "resolved": "https://registry.npmjs.org/log-driver/-/log-driver-1.2.5.tgz",
+            "integrity": "sha1-euTsJXMC/XkNVXyxDJcQDYV7AFY="
+        },
+        "lru-cache": {
+            "version": "4.1.1",
+            "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.1.tgz",
+            "integrity": "sha512-q4spe4KTfsAS1SUHLO0wz8Qiyf1+vMIAgpRYioFYDMNqKfHQbg+AVDH3i4fvpl71/P1L0dBl+fQi+P37UYf0ew=="
+        },
+        "mime-db": {
+            "version": "1.27.0",
+            "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.27.0.tgz",
+            "integrity": "sha1-gg9XIpa70g7CXtVeW13oaeVDbrE="
+        },
+        "mime-types": {
+            "version": "2.1.15",
+            "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.15.tgz",
+            "integrity": "sha1-pOv1BkCUVpI3uM9wBGd20J/JKu0="
+        },
+        "minimatch": {
+            "version": "3.0.4",
+            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
+            "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA=="
+        },
+        "minimist": {
+            "version": "1.2.0",
+            "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+            "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ="
+        },
+        "ms": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+            "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
+        },
+        "nodeunit": {
+            "version": "0.11.1",
+            "resolved": "https://registry.npmjs.org/nodeunit/-/nodeunit-0.11.1.tgz",
+            "integrity": "sha1-I9gP14tD1sJO4eS2RgDRV5F2GVw="
+        },
+        "nyc": {
+            "version": "11.0.2",
+            "resolved": "https://registry.npmjs.org/nyc/-/nyc-11.0.2.tgz",
+            "integrity": "sha512-31rRd6ME9NM17w0oPKqi51a6fzJAqYarnzQXK+iL8XaX+3H6VH0BQut7qHIgrv2mBASRic4oNi2KRgcbFODrsQ==",
+            "dependencies": {
+                "align-text": {
+                    "version": "0.1.4",
+                    "resolved": "https://registry.npmjs.org/align-text/-/align-text-0.1.4.tgz",
+                    "integrity": "sha1-DNkKVhCT810KmSVsIrcGlDP60Rc="
+                },
+                "amdefine": {
+                    "version": "1.0.1",
+                    "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.1.tgz",
+                    "integrity": "sha1-SlKCrBZHKek2Gbz9OtFR+BfOkfU="
+                },
+                "ansi-regex": {
+                    "version": "2.1.1",
+                    "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
+                    "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8="
+                },
+                "ansi-styles": {
+                    "version": "2.2.1",
+                    "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
+                    "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4="
+                },
+                "append-transform": {
+                    "version": "0.4.0",
+                    "resolved": "https://registry.npmjs.org/append-transform/-/append-transform-0.4.0.tgz",
+                    "integrity": "sha1-126/jKlNJ24keja61EpLdKthGZE="
+                },
+                "archy": {
+                    "version": "1.0.0",
+                    "resolved": "https://registry.npmjs.org/archy/-/archy-1.0.0.tgz",
+                    "integrity": "sha1-+cjBN1fMHde8N5rHeyxipcKGjEA="
+                },
+                "arr-diff": {
+                    "version": "2.0.0",
+                    "resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-2.0.0.tgz",
+                    "integrity": "sha1-jzuCf5Vai9ZpaX5KQlasPOrjVs8="
+                },
+                "arr-flatten": {
+                    "version": "1.0.3",
+                    "resolved": "https://registry.npmjs.org/arr-flatten/-/arr-flatten-1.0.3.tgz",
+                    "integrity": "sha1-onTthawIhJtr14R8RYB0XcUa37E="
+                },
+                "array-unique": {
+                    "version": "0.2.1",
+                    "resolved": "https://registry.npmjs.org/array-unique/-/array-unique-0.2.1.tgz",
+                    "integrity": "sha1-odl8yvy8JiXMcPrc6zalDFiwGlM="
+                },
+                "arrify": {
+                    "version": "1.0.1",
+                    "resolved": "https://registry.npmjs.org/arrify/-/arrify-1.0.1.tgz",
+                    "integrity": "sha1-iYUI2iIm84DfkEcoRWhJwVAaSw0="
+                },
+                "async": {
+                    "version": "1.5.2",
+                    "resolved": "https://registry.npmjs.org/async/-/async-1.5.2.tgz",
+                    "integrity": "sha1-7GphrlZIDAw8skHJVhjiCJL5Zyo="
+                },
+                "babel-code-frame": {
+                    "version": "6.22.0",
+                    "resolved": "https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.22.0.tgz",
+                    "integrity": "sha1-AnYgvuVnqIwyVhV05/0IAdMxGOQ="
+                },
+                "babel-generator": {
+                    "version": "6.24.1",
+                    "resolved": "https://registry.npmjs.org/babel-generator/-/babel-generator-6.24.1.tgz",
+                    "integrity": "sha1-5xX0hsWN7SVknYiJRNUqoHxdlJc="
+                },
+                "babel-messages": {
+                    "version": "6.23.0",
+                    "resolved": "https://registry.npmjs.org/babel-messages/-/babel-messages-6.23.0.tgz",
+                    "integrity": "sha1-8830cDhYA1sqKVHG7F7fbGLyYw4="
+                },
+                "babel-runtime": {
+                    "version": "6.23.0",
+                    "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.23.0.tgz",
+                    "integrity": "sha1-CpSJ8UTecO+zzkMArM2zKeL8VDs="
+                },
+                "babel-template": {
+                    "version": "6.24.1",
+                    "resolved": "https://registry.npmjs.org/babel-template/-/babel-template-6.24.1.tgz",
+                    "integrity": "sha1-BK5RTx+Ts6JTfyoPYKWkX7gwgzM="
+                },
+                "babel-traverse": {
+                    "version": "6.24.1",
+                    "resolved": "https://registry.npmjs.org/babel-traverse/-/babel-traverse-6.24.1.tgz",
+                    "integrity": "sha1-qzZnP9NW+aCUhlnnszjV/q2zFpU="
+                },
+                "babel-types": {
+                    "version": "6.24.1",
+                    "resolved": "https://registry.npmjs.org/babel-types/-/babel-types-6.24.1.tgz",
+                    "integrity": "sha1-oTaHncFbNga9oNkMH8dDBML/CXU="
+                },
+                "babylon": {
+                    "version": "6.17.2",
+                    "resolved": "https://registry.npmjs.org/babylon/-/babylon-6.17.2.tgz",
+                    "integrity": "sha1-IB0l71+JLEG65JSIsI2w3Udun1w="
+                },
+                "balanced-match": {
+                    "version": "0.4.2",
+                    "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.4.2.tgz",
+                    "integrity": "sha1-yz8+PHMtwPAe5wtAPzAuYddwmDg="
+                },
+                "brace-expansion": {
+                    "version": "1.1.7",
+                    "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.7.tgz",
+                    "integrity": "sha1-Pv/DxQ4ABTH7cg6v+A8K6O8jz1k="
+                },
+                "braces": {
+                    "version": "1.8.5",
+                    "resolved": "https://registry.npmjs.org/braces/-/braces-1.8.5.tgz",
+                    "integrity": "sha1-uneWLhLf+WnWt2cR6RS3N4V79qc="
+                },
+                "builtin-modules": {
+                    "version": "1.1.1",
+                    "resolved": "https://registry.npmjs.org/builtin-modules/-/builtin-modules-1.1.1.tgz",
+                    "integrity": "sha1-Jw8HbFpywC9bZaR9+Uxf46J4iS8="
+                },
+                "caching-transform": {
+                    "version": "1.0.1",
+                    "resolved": "https://registry.npmjs.org/caching-transform/-/caching-transform-1.0.1.tgz",
+                    "integrity": "sha1-bb2y8g+Nj7znnz6U6dF0Lc31wKE="
+                },
+                "center-align": {
+                    "version": "0.1.3",
+                    "resolved": "https://registry.npmjs.org/center-align/-/center-align-0.1.3.tgz",
+                    "integrity": "sha1-qg0yYptu6XIgBBHL1EYckHvCt60=",
+                    "optional": true
+                },
+                "chalk": {
+                    "version": "1.1.3",
+                    "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+                    "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg="
+                },
+                "cliui": {
+                    "version": "2.1.0",
+                    "resolved": "https://registry.npmjs.org/cliui/-/cliui-2.1.0.tgz",
+                    "integrity": "sha1-S0dXYP+AJkx2LDoXGQMukcf+oNE=",
+                    "optional": true,
+                    "dependencies": {
+                        "wordwrap": {
+                            "version": "0.0.2",
+                            "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.2.tgz",
+                            "integrity": "sha1-t5Zpu0LstAn4PVg8rVLKF+qhZD8=",
+                            "optional": true
+                        }
+                    }
+                },
+                "code-point-at": {
+                    "version": "1.1.0",
+                    "resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
+                    "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c="
+                },
+                "commondir": {
+                    "version": "1.0.1",
+                    "resolved": "https://registry.npmjs.org/commondir/-/commondir-1.0.1.tgz",
+                    "integrity": "sha1-3dgA2gxmEnOTzKWVDqloo6rxJTs="
+                },
+                "concat-map": {
+                    "version": "0.0.1",
+                    "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+                    "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
+                },
+                "convert-source-map": {
+                    "version": "1.5.0",
+                    "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.5.0.tgz",
+                    "integrity": "sha1-ms1whRxtXf3ZPZKC5e35SgP/RrU="
+                },
+                "core-js": {
+                    "version": "2.4.1",
+                    "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.4.1.tgz",
+                    "integrity": "sha1-TekR5mew6ukSTjQlS1OupvxhjT4="
+                },
+                "cross-spawn": {
+                    "version": "4.0.2",
+                    "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-4.0.2.tgz",
+                    "integrity": "sha1-e5JHYhwjrf3ThWAEqCPL45dCTUE="
+                },
+                "debug": {
+                    "version": "2.6.8",
+                    "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.8.tgz",
+                    "integrity": "sha1-5zFTHKLt4n0YgiJCfaF4IdaP9Pw="
+                },
+                "debug-log": {
+                    "version": "1.0.1",
+                    "resolved": "https://registry.npmjs.org/debug-log/-/debug-log-1.0.1.tgz",
+                    "integrity": "sha1-IwdjLUwEOCuN+KMvcLiVBG1SdF8="
+                },
+                "decamelize": {
+                    "version": "1.2.0",
+                    "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
+                    "integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA="
+                },
+                "default-require-extensions": {
+                    "version": "1.0.0",
+                    "resolved": "https://registry.npmjs.org/default-require-extensions/-/default-require-extensions-1.0.0.tgz",
+                    "integrity": "sha1-836hXT4T/9m0N9M+GnW1+5eHTLg="
+                },
+                "detect-indent": {
+                    "version": "4.0.0",
+                    "resolved": "https://registry.npmjs.org/detect-indent/-/detect-indent-4.0.0.tgz",
+                    "integrity": "sha1-920GQ1LN9Docts5hnE7jqUdd4gg="
+                },
+                "error-ex": {
+                    "version": "1.3.1",
+                    "resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.1.tgz",
+                    "integrity": "sha1-+FWobOYa3E6GIcPNoh56dhLDqNw="
+                },
+                "escape-string-regexp": {
+                    "version": "1.0.5",
+                    "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+                    "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ="
+                },
+                "esutils": {
+                    "version": "2.0.2",
+                    "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz",
+                    "integrity": "sha1-Cr9PHKpbyx96nYrMbepPqqBLrJs="
+                },
+                "execa": {
+                    "version": "0.5.1",
+                    "resolved": "https://registry.npmjs.org/execa/-/execa-0.5.1.tgz",
+                    "integrity": "sha1-3j+4XLjW6RyFvLzrFkWBeFy1ezY="
+                },
+                "expand-brackets": {
+                    "version": "0.1.5",
+                    "resolved": "https://registry.npmjs.org/expand-brackets/-/expand-brackets-0.1.5.tgz",
+                    "integrity": "sha1-3wcoTjQqgHzXM6xa9yQR5YHRF3s="
+                },
+                "expand-range": {
+                    "version": "1.8.2",
+                    "resolved": "https://registry.npmjs.org/expand-range/-/expand-range-1.8.2.tgz",
+                    "integrity": "sha1-opnv/TNf4nIeuujiV+x5ZE/IUzc="
+                },
+                "extglob": {
+                    "version": "0.3.2",
+                    "resolved": "https://registry.npmjs.org/extglob/-/extglob-0.3.2.tgz",
+                    "integrity": "sha1-Lhj/PS9JqydlzskCPwEdqo2DSaE="
+                },
+                "filename-regex": {
+                    "version": "2.0.1",
+                    "resolved": "https://registry.npmjs.org/filename-regex/-/filename-regex-2.0.1.tgz",
+                    "integrity": "sha1-wcS5vuPglyXdsQa3XB4wH+LxiyY="
+                },
+                "fill-range": {
+                    "version": "2.2.3",
+                    "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-2.2.3.tgz",
+                    "integrity": "sha1-ULd9/X5Gm8dJJHCWNpn+eoSFpyM="
+                },
+                "find-cache-dir": {
+                    "version": "0.1.1",
+                    "resolved": "https://registry.npmjs.org/find-cache-dir/-/find-cache-dir-0.1.1.tgz",
+                    "integrity": "sha1-yN765XyKUqinhPnjHFfHQumToLk="
+                },
+                "find-up": {
+                    "version": "2.1.0",
+                    "resolved": "https://registry.npmjs.org/find-up/-/find-up-2.1.0.tgz",
+                    "integrity": "sha1-RdG35QbHF93UgndaK3eSCjwMV6c="
+                },
+                "for-in": {
+                    "version": "1.0.2",
+                    "resolved": "https://registry.npmjs.org/for-in/-/for-in-1.0.2.tgz",
+                    "integrity": "sha1-gQaNKVqBQuwKxybG4iAMMPttXoA="
+                },
+                "for-own": {
+                    "version": "0.1.5",
+                    "resolved": "https://registry.npmjs.org/for-own/-/for-own-0.1.5.tgz",
+                    "integrity": "sha1-UmXGgaTylNq78XyVCbZ2OqhFEM4="
+                },
+                "foreground-child": {
+                    "version": "1.5.6",
+                    "resolved": "https://registry.npmjs.org/foreground-child/-/foreground-child-1.5.6.tgz",
+                    "integrity": "sha1-T9ca0t/elnibmApcCilZN8svXOk="
+                },
+                "fs.realpath": {
+                    "version": "1.0.0",
+                    "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
+                    "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8="
+                },
+                "get-caller-file": {
+                    "version": "1.0.2",
+                    "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-1.0.2.tgz",
+                    "integrity": "sha1-9wLmMSfn4jHBYKgMFVSstw1QR+U="
+                },
+                "get-stream": {
+                    "version": "2.3.1",
+                    "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-2.3.1.tgz",
+                    "integrity": "sha1-Xzj5PzRgCWZu4BUKBUFn+Rvdld4="
+                },
+                "glob": {
+                    "version": "7.1.2",
+                    "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
+                    "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ=="
+                },
+                "glob-base": {
+                    "version": "0.3.0",
+                    "resolved": "https://registry.npmjs.org/glob-base/-/glob-base-0.3.0.tgz",
+                    "integrity": "sha1-27Fk9iIbHAscz4Kuoyi0l98Oo8Q="
+                },
+                "glob-parent": {
+                    "version": "2.0.0",
+                    "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-2.0.0.tgz",
+                    "integrity": "sha1-gTg9ctsFT8zPUzbaqQLxgvbtuyg="
+                },
+                "globals": {
+                    "version": "9.17.0",
+                    "resolved": "https://registry.npmjs.org/globals/-/globals-9.17.0.tgz",
+                    "integrity": "sha1-DAymltm5u2lNLlRwvTd3fKrVAoY="
+                },
+                "graceful-fs": {
+                    "version": "4.1.11",
+                    "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz",
+                    "integrity": "sha1-Dovf5NHduIVNZOBOp8AOKgJuVlg="
+                },
+                "handlebars": {
+                    "version": "4.0.10",
+                    "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.0.10.tgz",
+                    "integrity": "sha1-PTDHGLCaPZbyPqTMH0A8TTup/08=",
+                    "dependencies": {
+                        "source-map": {
+                            "version": "0.4.4",
+                            "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.4.4.tgz",
+                            "integrity": "sha1-66T12pwNyZneaAMti092FzZSA2s="
+                        }
+                    }
+                },
+                "has-ansi": {
+                    "version": "2.0.0",
+                    "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
+                    "integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE="
+                },
+                "has-flag": {
+                    "version": "1.0.0",
+                    "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz",
+                    "integrity": "sha1-nZ55MWXOAXoA8AQYxD+UKnsdEfo="
+                },
+                "hosted-git-info": {
+                    "version": "2.4.2",
+                    "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.4.2.tgz",
+                    "integrity": "sha1-AHa59GonBQbduq6lZJaJdGBhKmc="
+                },
+                "imurmurhash": {
+                    "version": "0.1.4",
+                    "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
+                    "integrity": "sha1-khi5srkoojixPcT7a21XbyMUU+o="
+                },
+                "inflight": {
+                    "version": "1.0.6",
+                    "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+                    "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk="
+                },
+                "inherits": {
+                    "version": "2.0.3",
+                    "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+                    "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4="
+                },
+                "invariant": {
+                    "version": "2.2.2",
+                    "resolved": "https://registry.npmjs.org/invariant/-/invariant-2.2.2.tgz",
+                    "integrity": "sha1-nh9WrArNtr8wMwbzOL47IErmA2A="
+                },
+                "invert-kv": {
+                    "version": "1.0.0",
+                    "resolved": "https://registry.npmjs.org/invert-kv/-/invert-kv-1.0.0.tgz",
+                    "integrity": "sha1-EEqOSqym09jNFXqO+L+rLXo//bY="
+                },
+                "is-arrayish": {
+                    "version": "0.2.1",
+                    "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
+                    "integrity": "sha1-d8mYQFJ6qOyxqLppe4BkWnqSap0="
+                },
+                "is-buffer": {
+                    "version": "1.1.5",
+                    "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.5.tgz",
+                    "integrity": "sha1-Hzsm72E7IUuIy8ojzGwB2Hlh7sw="
+                },
+                "is-builtin-module": {
+                    "version": "1.0.0",
+                    "resolved": "https://registry.npmjs.org/is-builtin-module/-/is-builtin-module-1.0.0.tgz",
+                    "integrity": "sha1-VAVy0096wxGfj3bDDLwbHgN6/74="
+                },
+                "is-dotfile": {
+                    "version": "1.0.3",
+                    "resolved": "https://registry.npmjs.org/is-dotfile/-/is-dotfile-1.0.3.tgz",
+                    "integrity": "sha1-pqLzL/0t+wT1yiXs0Pa4PPeYoeE="
+                },
+                "is-equal-shallow": {
+                    "version": "0.1.3",
+                    "resolved": "https://registry.npmjs.org/is-equal-shallow/-/is-equal-shallow-0.1.3.tgz",
+                    "integrity": "sha1-IjgJj8Ih3gvPpdnqxMRdY4qhxTQ="
+                },
+                "is-extendable": {
+                    "version": "0.1.1",
+                    "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-0.1.1.tgz",
+                    "integrity": "sha1-YrEQ4omkcUGOPsNqYX1HLjAd/Ik="
+                },
+                "is-extglob": {
+                    "version": "1.0.0",
+                    "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz",
+                    "integrity": "sha1-rEaBd8SUNAWgkvyPKXYMb/xiBsA="
+                },
+                "is-finite": {
+                    "version": "1.0.2",
+                    "resolved": "https://registry.npmjs.org/is-finite/-/is-finite-1.0.2.tgz",
+                    "integrity": "sha1-zGZ3aVYCvlUO8R6LSqYwU0K20Ko="
+                },
+                "is-fullwidth-code-point": {
+                    "version": "1.0.0",
+                    "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
+                    "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs="
+                },
+                "is-glob": {
+                    "version": "2.0.1",
+                    "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz",
+                    "integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM="
+                },
+                "is-number": {
+                    "version": "2.1.0",
+                    "resolved": "https://registry.npmjs.org/is-number/-/is-number-2.1.0.tgz",
+                    "integrity": "sha1-Afy7s5NGOlSPL0ZszhbezknbkI8="
+                },
+                "is-posix-bracket": {
+                    "version": "0.1.1",
+                    "resolved": "https://registry.npmjs.org/is-posix-bracket/-/is-posix-bracket-0.1.1.tgz",
+                    "integrity": "sha1-MzTceXdDaOkvAW5vvAqI9c1ua8Q="
+                },
+                "is-primitive": {
+                    "version": "2.0.0",
+                    "resolved": "https://registry.npmjs.org/is-primitive/-/is-primitive-2.0.0.tgz",
+                    "integrity": "sha1-IHurkWOEmcB7Kt8kCkGochADRXU="
+                },
+                "is-stream": {
+                    "version": "1.1.0",
+                    "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
+                    "integrity": "sha1-EtSj3U5o4Lec6428hBc66A2RykQ="
+                },
+                "is-utf8": {
+                    "version": "0.2.1",
+                    "resolved": "https://registry.npmjs.org/is-utf8/-/is-utf8-0.2.1.tgz",
+                    "integrity": "sha1-Sw2hRCEE0bM2NA6AeX6GXPOffXI="
+                },
+                "isarray": {
+                    "version": "1.0.0",
+                    "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+                    "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
+                },
+                "isexe": {
+                    "version": "2.0.0",
+                    "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+                    "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA="
+                },
+                "isobject": {
+                    "version": "2.1.0",
+                    "resolved": "https://registry.npmjs.org/isobject/-/isobject-2.1.0.tgz",
+                    "integrity": "sha1-8GVWEJaj8dou9GJy+BXIQNh+DIk="
+                },
+                "istanbul-lib-coverage": {
+                    "version": "1.1.1",
+                    "resolved": "https://registry.npmjs.org/istanbul-lib-coverage/-/istanbul-lib-coverage-1.1.1.tgz",
+                    "integrity": "sha512-0+1vDkmzxqJIn5rcoEqapSB4DmPxE31EtI2dF2aCkV5esN9EWHxZ0dwgDClivMXJqE7zaYQxq30hj5L0nlTN5Q=="
+                },
+                "istanbul-lib-hook": {
+                    "version": "1.0.7",
+                    "resolved": "https://registry.npmjs.org/istanbul-lib-hook/-/istanbul-lib-hook-1.0.7.tgz",
+                    "integrity": "sha512-3U2HB9y1ZV9UmFlE12Fx+nPtFqIymzrqCksrXujm3NVbAZIJg/RfYgO1XiIa0mbmxTjWpVEVlkIZJ25xVIAfkQ=="
+                },
+                "istanbul-lib-instrument": {
+                    "version": "1.7.2",
+                    "resolved": "https://registry.npmjs.org/istanbul-lib-instrument/-/istanbul-lib-instrument-1.7.2.tgz",
+                    "integrity": "sha512-lPgUY+Pa5dlq2/l0qs1PJZ54QPSfo+s4+UZdkb2d0hbOyrEIAbUJphBLFjEyXBdeCONgGRADFzs3ojfFtmuwFA=="
+                },
+                "istanbul-lib-report": {
+                    "version": "1.1.1",
+                    "resolved": "https://registry.npmjs.org/istanbul-lib-report/-/istanbul-lib-report-1.1.1.tgz",
+                    "integrity": "sha512-tvF+YmCmH4thnez6JFX06ujIA19WPa9YUiwjc1uALF2cv5dmE3It8b5I8Ob7FHJ70H9Y5yF+TDkVa/mcADuw1Q==",
+                    "dependencies": {
+                        "supports-color": {
+                            "version": "3.2.3",
+                            "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-3.2.3.tgz",
+                            "integrity": "sha1-ZawFBLOVQXHYpklGsq48u4pfVPY="
+                        }
+                    }
+                },
+                "istanbul-lib-source-maps": {
+                    "version": "1.2.1",
+                    "resolved": "https://registry.npmjs.org/istanbul-lib-source-maps/-/istanbul-lib-source-maps-1.2.1.tgz",
+                    "integrity": "sha512-mukVvSXCn9JQvdJl8wP/iPhqig0MRtuWuD4ZNKo6vB2Ik//AmhAKe3QnPN02dmkRe3lTudFk3rzoHhwU4hb94w=="
+                },
+                "istanbul-reports": {
+                    "version": "1.1.1",
+                    "resolved": "https://registry.npmjs.org/istanbul-reports/-/istanbul-reports-1.1.1.tgz",
+                    "integrity": "sha512-P8G873A0kW24XRlxHVGhMJBhQ8gWAec+dae7ZxOBzxT4w+a9ATSPvRVK3LB1RAJ9S8bg2tOyWHAGW40Zd2dKfw=="
+                },
+                "js-tokens": {
+                    "version": "3.0.1",
+                    "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-3.0.1.tgz",
+                    "integrity": "sha1-COnxMkhKLEWjCQfp3E1VZ7fxFNc="
+                },
+                "jsesc": {
+                    "version": "1.3.0",
+                    "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-1.3.0.tgz",
+                    "integrity": "sha1-RsP+yMGJKxKwgz25vHYiF226s0s="
+                },
+                "kind-of": {
+                    "version": "3.2.2",
+                    "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+                    "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ="
+                },
+                "lazy-cache": {
+                    "version": "1.0.4",
+                    "resolved": "https://registry.npmjs.org/lazy-cache/-/lazy-cache-1.0.4.tgz",
+                    "integrity": "sha1-odePw6UEdMuAhF07O24dpJpEbo4=",
+                    "optional": true
+                },
+                "lcid": {
+                    "version": "1.0.0",
+                    "resolved": "https://registry.npmjs.org/lcid/-/lcid-1.0.0.tgz",
+                    "integrity": "sha1-MIrMr6C8SDo4Z7S28rlQYlHRuDU="
+                },
+                "load-json-file": {
+                    "version": "1.1.0",
+                    "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-1.1.0.tgz",
+                    "integrity": "sha1-lWkFcI1YtLq0wiYbBPWfMcmTdMA="
+                },
+                "locate-path": {
+                    "version": "2.0.0",
+                    "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-2.0.0.tgz",
+                    "integrity": "sha1-K1aLJl7slExtnA3pw9u7ygNUzY4=",
+                    "dependencies": {
+                        "path-exists": {
+                            "version": "3.0.0",
+                            "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-3.0.0.tgz",
+                            "integrity": "sha1-zg6+ql94yxiSXqfYENe1mwEP1RU="
+                        }
+                    }
+                },
+                "lodash": {
+                    "version": "4.17.4",
+                    "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz",
+                    "integrity": "sha1-eCA6TRwyiuHYbcpkYONptX9AVa4="
+                },
+                "longest": {
+                    "version": "1.0.1",
+                    "resolved": "https://registry.npmjs.org/longest/-/longest-1.0.1.tgz",
+                    "integrity": "sha1-MKCy2jj3N3DoKUoNIuZiXtd9AJc="
+                },
+                "loose-envify": {
+                    "version": "1.3.1",
+                    "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.3.1.tgz",
+                    "integrity": "sha1-0aitM/qc4OcT1l/dCsi3SNR4yEg="
+                },
+                "lru-cache": {
+                    "version": "4.0.2",
+                    "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.0.2.tgz",
+                    "integrity": "sha1-HRdnnAac2l0ECZGgnbwsDbN35V4="
+                },
+                "md5-hex": {
+                    "version": "1.3.0",
+                    "resolved": "https://registry.npmjs.org/md5-hex/-/md5-hex-1.3.0.tgz",
+                    "integrity": "sha1-0sSv6YPENwZiF5uMrRRSGRNQRsQ="
+                },
+                "md5-o-matic": {
+                    "version": "0.1.1",
+                    "resolved": "https://registry.npmjs.org/md5-o-matic/-/md5-o-matic-0.1.1.tgz",
+                    "integrity": "sha1-givM1l4RfFFPqxdrJZRdVBAKA8M="
+                },
+                "mem": {
+                    "version": "1.1.0",
+                    "resolved": "https://registry.npmjs.org/mem/-/mem-1.1.0.tgz",
+                    "integrity": "sha1-Xt1StIXKHZAP5kiVUFOZoN+kX3Y="
+                },
+                "merge-source-map": {
+                    "version": "1.0.3",
+                    "resolved": "https://registry.npmjs.org/merge-source-map/-/merge-source-map-1.0.3.tgz",
+                    "integrity": "sha1-2hQV8nIqURnbB7FMT5c0EIY6Kr8="
+                },
+                "micromatch": {
+                    "version": "2.3.11",
+                    "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-2.3.11.tgz",
+                    "integrity": "sha1-hmd8l9FyCzY0MdBNDRUpO9OMFWU="
+                },
+                "mimic-fn": {
+                    "version": "1.1.0",
+                    "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-1.1.0.tgz",
+                    "integrity": "sha1-5md4PZLonb00KBi1IwudYqZyrRg="
+                },
+                "minimatch": {
+                    "version": "3.0.4",
+                    "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
+                    "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA=="
+                },
+                "minimist": {
+                    "version": "0.0.8",
+                    "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
+                    "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0="
+                },
+                "mkdirp": {
+                    "version": "0.5.1",
+                    "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+                    "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM="
+                },
+                "ms": {
+                    "version": "2.0.0",
+                    "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+                    "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
+                },
+                "normalize-package-data": {
+                    "version": "2.3.8",
+                    "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.3.8.tgz",
+                    "integrity": "sha1-2Bntoqne29H/pWPqQHHZNngilbs="
+                },
+                "normalize-path": {
+                    "version": "2.1.1",
+                    "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-2.1.1.tgz",
+                    "integrity": "sha1-GrKLVW4Zg2Oowab35vogE3/mrtk="
+                },
+                "npm-run-path": {
+                    "version": "2.0.2",
+                    "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-2.0.2.tgz",
+                    "integrity": "sha1-NakjLfo11wZ7TLLd8jV7GHFTbF8="
+                },
+                "number-is-nan": {
+                    "version": "1.0.1",
+                    "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
+                    "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0="
+                },
+                "object-assign": {
+                    "version": "4.1.1",
+                    "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+                    "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM="
+                },
+                "object.omit": {
+                    "version": "2.0.1",
+                    "resolved": "https://registry.npmjs.org/object.omit/-/object.omit-2.0.1.tgz",
+                    "integrity": "sha1-Gpx0SCnznbuFjHbKNXmuKlTr0fo="
+                },
+                "once": {
+                    "version": "1.4.0",
+                    "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+                    "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E="
+                },
+                "optimist": {
+                    "version": "0.6.1",
+                    "resolved": "https://registry.npmjs.org/optimist/-/optimist-0.6.1.tgz",
+                    "integrity": "sha1-2j6nRob6IaGaERwybpDrFaAZZoY="
+                },
+                "os-homedir": {
+                    "version": "1.0.2",
+                    "resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz",
+                    "integrity": "sha1-/7xJiDNuDoM94MFox+8VISGqf7M="
+                },
+                "os-locale": {
+                    "version": "2.0.0",
+                    "resolved": "https://registry.npmjs.org/os-locale/-/os-locale-2.0.0.tgz",
+                    "integrity": "sha1-FZGN7VEFIrge565aMJ1U9jn8OaQ="
+                },
+                "p-finally": {
+                    "version": "1.0.0",
+                    "resolved": "https://registry.npmjs.org/p-finally/-/p-finally-1.0.0.tgz",
+                    "integrity": "sha1-P7z7FbiZpEEjs0ttzBi3JDNqLK4="
+                },
+                "p-limit": {
+                    "version": "1.1.0",
+                    "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-1.1.0.tgz",
+                    "integrity": "sha1-sH/y2aXYi+yAYDWJWiurZqJ5iLw="
+                },
+                "p-locate": {
+                    "version": "2.0.0",
+                    "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-2.0.0.tgz",
+                    "integrity": "sha1-IKAQOyIqcMj9OcwuWAaA893l7EM="
+                },
+                "parse-glob": {
+                    "version": "3.0.4",
+                    "resolved": "https://registry.npmjs.org/parse-glob/-/parse-glob-3.0.4.tgz",
+                    "integrity": "sha1-ssN2z7EfNVE7rdFz7wu246OIORw="
+                },
+                "parse-json": {
+                    "version": "2.2.0",
+                    "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-2.2.0.tgz",
+                    "integrity": "sha1-9ID0BDTvgHQfhGkJn43qGPVaTck="
+                },
+                "path-exists": {
+                    "version": "2.1.0",
+                    "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-2.1.0.tgz",
+                    "integrity": "sha1-D+tsZPD8UY2adU3V77YscCJ2H0s="
+                },
+                "path-is-absolute": {
+                    "version": "1.0.1",
+                    "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+                    "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18="
+                },
+                "path-key": {
+                    "version": "2.0.1",
+                    "resolved": "https://registry.npmjs.org/path-key/-/path-key-2.0.1.tgz",
+                    "integrity": "sha1-QRyttXTFoUDTpLGRDUDYDMn0C0A="
+                },
+                "path-parse": {
+                    "version": "1.0.5",
+                    "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.5.tgz",
+                    "integrity": "sha1-PBrfhx6pzWyUMbbqK9dKD/BVxME="
+                },
+                "path-type": {
+                    "version": "1.1.0",
+                    "resolved": "https://registry.npmjs.org/path-type/-/path-type-1.1.0.tgz",
+                    "integrity": "sha1-WcRPfuSR2nBNpBXaWkBwuk+P5EE="
+                },
+                "pify": {
+                    "version": "2.3.0",
+                    "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
+                    "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw="
+                },
+                "pinkie": {
+                    "version": "2.0.4",
+                    "resolved": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz",
+                    "integrity": "sha1-clVrgM+g1IqXToDnckjoDtT3+HA="
+                },
+                "pinkie-promise": {
+                    "version": "2.0.1",
+                    "resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
+                    "integrity": "sha1-ITXW36ejWMBprJsXh3YogihFD/o="
+                },
+                "pkg-dir": {
+                    "version": "1.0.0",
+                    "resolved": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-1.0.0.tgz",
+                    "integrity": "sha1-ektQio1bstYp1EcFb/TpyTFM89Q=",
+                    "dependencies": {
+                        "find-up": {
+                            "version": "1.1.2",
+                            "resolved": "https://registry.npmjs.org/find-up/-/find-up-1.1.2.tgz",
+                            "integrity": "sha1-ay6YIrGizgpgq2TWEOzK1TyyTQ8="
+                        }
+                    }
+                },
+                "preserve": {
+                    "version": "0.2.0",
+                    "resolved": "https://registry.npmjs.org/preserve/-/preserve-0.2.0.tgz",
+                    "integrity": "sha1-gV7R9uvGWSb4ZbMQwHE7yzMVzks="
+                },
+                "pseudomap": {
+                    "version": "1.0.2",
+                    "resolved": "https://registry.npmjs.org/pseudomap/-/pseudomap-1.0.2.tgz",
+                    "integrity": "sha1-8FKijacOYYkX7wqKw0wa5aaChrM="
+                },
+                "randomatic": {
+                    "version": "1.1.6",
+                    "resolved": "https://registry.npmjs.org/randomatic/-/randomatic-1.1.6.tgz",
+                    "integrity": "sha1-EQ3Kv/OX6dz/fAeJzMCkmt8exbs="
+                },
+                "read-pkg": {
+                    "version": "1.1.0",
+                    "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-1.1.0.tgz",
+                    "integrity": "sha1-9f+qXs0pyzHAR0vKfXVra7KePyg="
+                },
+                "read-pkg-up": {
+                    "version": "1.0.1",
+                    "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-1.0.1.tgz",
+                    "integrity": "sha1-nWPBMnbAZZGNV/ACpX9AobZD+wI=",
+                    "dependencies": {
+                        "find-up": {
+                            "version": "1.1.2",
+                            "resolved": "https://registry.npmjs.org/find-up/-/find-up-1.1.2.tgz",
+                            "integrity": "sha1-ay6YIrGizgpgq2TWEOzK1TyyTQ8="
+                        }
+                    }
+                },
+                "regenerator-runtime": {
+                    "version": "0.10.5",
+                    "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.10.5.tgz",
+                    "integrity": "sha1-M2w+/BIgrc7dosn6tntaeVWjNlg="
+                },
+                "regex-cache": {
+                    "version": "0.4.3",
+                    "resolved": "https://registry.npmjs.org/regex-cache/-/regex-cache-0.4.3.tgz",
+                    "integrity": "sha1-mxpsNdTQ3871cRrmUejp09cRQUU="
+                },
+                "remove-trailing-separator": {
+                    "version": "1.0.1",
+                    "resolved": "https://registry.npmjs.org/remove-trailing-separator/-/remove-trailing-separator-1.0.1.tgz",
+                    "integrity": "sha1-YV67lq9VlVLUv0BXyENtSGq2PMQ="
+                },
+                "repeat-element": {
+                    "version": "1.1.2",
+                    "resolved": "https://registry.npmjs.org/repeat-element/-/repeat-element-1.1.2.tgz",
+                    "integrity": "sha1-7wiaF40Ug7quTZPrmLT55OEdmQo="
+                },
+                "repeat-string": {
+                    "version": "1.6.1",
+                    "resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.6.1.tgz",
+                    "integrity": "sha1-jcrkcOHIirwtYA//Sndihtp15jc="
+                },
+                "repeating": {
+                    "version": "2.0.1",
+                    "resolved": "https://registry.npmjs.org/repeating/-/repeating-2.0.1.tgz",
+                    "integrity": "sha1-UhTFOpJtNVJwdSf7q0FdvAjQbdo="
+                },
+                "require-directory": {
+                    "version": "2.1.1",
+                    "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
+                    "integrity": "sha1-jGStX9MNqxyXbiNE/+f3kqam30I="
+                },
+                "require-main-filename": {
+                    "version": "1.0.1",
+                    "resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-1.0.1.tgz",
+                    "integrity": "sha1-l/cXtp1IeE9fUmpsWqj/3aBVpNE="
+                },
+                "resolve-from": {
+                    "version": "2.0.0",
+                    "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-2.0.0.tgz",
+                    "integrity": "sha1-lICrIOlP+h2egKgEx+oUdhGWa1c="
+                },
+                "right-align": {
+                    "version": "0.1.3",
+                    "resolved": "https://registry.npmjs.org/right-align/-/right-align-0.1.3.tgz",
+                    "integrity": "sha1-YTObci/mo1FWiSENJOFMlhSGE+8=",
+                    "optional": true
+                },
+                "rimraf": {
+                    "version": "2.6.1",
+                    "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.1.tgz",
+                    "integrity": "sha1-wjOOxkPfeht/5cVPqG9XQopV8z0="
+                },
+                "semver": {
+                    "version": "5.3.0",
+                    "resolved": "https://registry.npmjs.org/semver/-/semver-5.3.0.tgz",
+                    "integrity": "sha1-myzl094C0XxgEq0yaqa00M9U+U8="
+                },
+                "set-blocking": {
+                    "version": "2.0.0",
+                    "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
+                    "integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc="
+                },
+                "signal-exit": {
+                    "version": "3.0.2",
+                    "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz",
+                    "integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0="
+                },
+                "slide": {
+                    "version": "1.1.6",
+                    "resolved": "https://registry.npmjs.org/slide/-/slide-1.1.6.tgz",
+                    "integrity": "sha1-VusCfWW00tzmyy4tMsTUr8nh1wc="
+                },
+                "source-map": {
+                    "version": "0.5.6",
+                    "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.6.tgz",
+                    "integrity": "sha1-dc449SvwczxafwwRjYEzSiu19BI="
+                },
+                "spawn-wrap": {
+                    "version": "1.3.6",
+                    "resolved": "https://registry.npmjs.org/spawn-wrap/-/spawn-wrap-1.3.6.tgz",
+                    "integrity": "sha512-5bEhZ11kqwoECJwfbur2ALU1NBnnCNbFzdWGHEXCiSsVhH+Ubz6eesa1DuQcm05pk38HknqP556f3CFhqws2ZA=="
+                },
+                "spdx-correct": {
+                    "version": "1.0.2",
+                    "resolved": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-1.0.2.tgz",
+                    "integrity": "sha1-SzBz2TP/UfORLwOsVRlJikFQ20A="
+                },
+                "spdx-expression-parse": {
+                    "version": "1.0.4",
+                    "resolved": "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-1.0.4.tgz",
+                    "integrity": "sha1-m98vIOH0DtRH++JzJmGR/O1RYmw="
+                },
+                "spdx-license-ids": {
+                    "version": "1.2.2",
+                    "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-1.2.2.tgz",
+                    "integrity": "sha1-yd96NCRZSt5r0RkA1ZZpbcBrrFc="
+                },
+                "string-width": {
+                    "version": "2.0.0",
+                    "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.0.0.tgz",
+                    "integrity": "sha1-Y1xUNsxypuDDh87KJ41OLuxSaH4=",
+                    "dependencies": {
+                        "is-fullwidth-code-point": {
+                            "version": "2.0.0",
+                            "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
+                            "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8="
+                        }
+                    }
+                },
+                "strip-ansi": {
+                    "version": "3.0.1",
+                    "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+                    "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8="
+                },
+                "strip-bom": {
+                    "version": "2.0.0",
+                    "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-2.0.0.tgz",
+                    "integrity": "sha1-YhmoVhZSBJHzV4i9vxRHqZx+aw4="
+                },
+                "strip-eof": {
+                    "version": "1.0.0",
+                    "resolved": "https://registry.npmjs.org/strip-eof/-/strip-eof-1.0.0.tgz",
+                    "integrity": "sha1-u0P/VZim6wXYm1n80SnJgzE2Br8="
+                },
+                "supports-color": {
+                    "version": "2.0.0",
+                    "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
+                    "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc="
+                },
+                "test-exclude": {
+                    "version": "4.1.1",
+                    "resolved": "https://registry.npmjs.org/test-exclude/-/test-exclude-4.1.1.tgz",
+                    "integrity": "sha512-35+Asrsk3XHJDBgf/VRFexPgh3UyETv8IAn/LRTiZjVy6rjPVqdEk8dJcJYBzl1w0XCJM48lvTy8SfEsCWS4nA=="
+                },
+                "to-fast-properties": {
+                    "version": "1.0.3",
+                    "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-1.0.3.tgz",
+                    "integrity": "sha1-uDVx+k2MJbguIxsG46MFXeTKGkc="
+                },
+                "trim-right": {
+                    "version": "1.0.1",
+                    "resolved": "https://registry.npmjs.org/trim-right/-/trim-right-1.0.1.tgz",
+                    "integrity": "sha1-yy4SAwZ+DI3h9hQJS5/kVwTqYAM="
+                },
+                "uglify-js": {
+                    "version": "2.8.27",
+                    "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-2.8.27.tgz",
+                    "integrity": "sha1-R3h/kSsPJC5bmENDvo416V9pTJw=",
+                    "optional": true,
+                    "dependencies": {
+                        "camelcase": {
+                            "version": "1.2.1",
+                            "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-1.2.1.tgz",
+                            "integrity": "sha1-m7UwTS4LVmmLLHWLCKPqqdqlijk=",
+                            "optional": true
+                        },
+                        "yargs": {
+                            "version": "3.10.0",
+                            "resolved": "https://registry.npmjs.org/yargs/-/yargs-3.10.0.tgz",
+                            "integrity": "sha1-9+572FfdfB0tOMDnTvvWgdFDH9E=",
+                            "optional": true
+                        }
+                    }
+                },
+                "uglify-to-browserify": {
+                    "version": "1.0.2",
+                    "resolved": "https://registry.npmjs.org/uglify-to-browserify/-/uglify-to-browserify-1.0.2.tgz",
+                    "integrity": "sha1-bgkk1r2mta/jSeOabWMoUKD4grc=",
+                    "optional": true
+                },
+                "validate-npm-package-license": {
+                    "version": "3.0.1",
+                    "resolved": "https://registry.npmjs.org/validate-npm-package-license/-/validate-npm-package-license-3.0.1.tgz",
+                    "integrity": "sha1-KAS6vnEq0zeUWaz74kdGqywwP7w="
+                },
+                "which": {
+                    "version": "1.2.14",
+                    "resolved": "https://registry.npmjs.org/which/-/which-1.2.14.tgz",
+                    "integrity": "sha1-mofEN48D6CfOyvGs31bHNsAcFOU="
+                },
+                "which-module": {
+                    "version": "2.0.0",
+                    "resolved": "https://registry.npmjs.org/which-module/-/which-module-2.0.0.tgz",
+                    "integrity": "sha1-2e8H3Od7mQK4o6j6SzHD4/fm6Ho="
+                },
+                "window-size": {
+                    "version": "0.1.0",
+                    "resolved": "https://registry.npmjs.org/window-size/-/window-size-0.1.0.tgz",
+                    "integrity": "sha1-VDjNLqk7IC76Ohn+iIeu58lPnJ0=",
+                    "optional": true
+                },
+                "wordwrap": {
+                    "version": "0.0.3",
+                    "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.3.tgz",
+                    "integrity": "sha1-o9XabNXAvAAI03I0u68b7WMFkQc="
+                },
+                "wrap-ansi": {
+                    "version": "2.1.0",
+                    "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-2.1.0.tgz",
+                    "integrity": "sha1-2Pw9KE3QV5T+hJc8rs3Rz4JP3YU=",
+                    "dependencies": {
+                        "string-width": {
+                            "version": "1.0.2",
+                            "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
+                            "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M="
+                        }
+                    }
+                },
+                "wrappy": {
+                    "version": "1.0.2",
+                    "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+                    "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
+                },
+                "write-file-atomic": {
+                    "version": "1.3.4",
+                    "resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-1.3.4.tgz",
+                    "integrity": "sha1-+Aek8LHZ6ROuekgRLmzDrxmRtF8="
+                },
+                "y18n": {
+                    "version": "3.2.1",
+                    "resolved": "https://registry.npmjs.org/y18n/-/y18n-3.2.1.tgz",
+                    "integrity": "sha1-bRX7qITAhnnA136I53WegR4H+kE="
+                },
+                "yallist": {
+                    "version": "2.1.2",
+                    "resolved": "https://registry.npmjs.org/yallist/-/yallist-2.1.2.tgz",
+                    "integrity": "sha1-HBH5IY8HYImkfdUS+TxmmaaoHVI="
+                },
+                "yargs": {
+                    "version": "8.0.1",
+                    "resolved": "https://registry.npmjs.org/yargs/-/yargs-8.0.1.tgz",
+                    "integrity": "sha1-Qg73XoQMFFeoCtzKm8b6OEneUao=",
+                    "dependencies": {
+                        "camelcase": {
+                            "version": "4.1.0",
+                            "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-4.1.0.tgz",
+                            "integrity": "sha1-1UVjW+HjPFQmScaRc+Xeas+uNN0="
+                        },
+                        "cliui": {
+                            "version": "3.2.0",
+                            "resolved": "https://registry.npmjs.org/cliui/-/cliui-3.2.0.tgz",
+                            "integrity": "sha1-EgYBU3qRbSmUD5NNo7SNWFo5IT0=",
+                            "dependencies": {
+                                "string-width": {
+                                    "version": "1.0.2",
+                                    "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
+                                    "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M="
+                                }
+                            }
+                        },
+                        "load-json-file": {
+                            "version": "2.0.0",
+                            "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-2.0.0.tgz",
+                            "integrity": "sha1-eUfkIUmvgNaWy/eXvKq8/h/inKg="
+                        },
+                        "path-type": {
+                            "version": "2.0.0",
+                            "resolved": "https://registry.npmjs.org/path-type/-/path-type-2.0.0.tgz",
+                            "integrity": "sha1-8BLMuEFbcJb8LaoQVMPXI4lZTHM="
+                        },
+                        "read-pkg": {
+                            "version": "2.0.0",
+                            "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-2.0.0.tgz",
+                            "integrity": "sha1-jvHAYjxqbbDcZxPEv6xGMysjaPg="
+                        },
+                        "read-pkg-up": {
+                            "version": "2.0.0",
+                            "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-2.0.0.tgz",
+                            "integrity": "sha1-a3KoBImE4MQeeVEP1en6mbO1Sb4="
+                        },
+                        "strip-bom": {
+                            "version": "3.0.0",
+                            "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz",
+                            "integrity": "sha1-IzTBjpx1n3vdVv3vfprj1YjmjtM="
+                        },
+                        "yargs-parser": {
+                            "version": "7.0.0",
+                            "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-7.0.0.tgz",
+                            "integrity": "sha1-jQrELxbqVd69MyyvTEA4s+P139k="
+                        }
+                    }
+                },
+                "yargs-parser": {
+                    "version": "5.0.0",
+                    "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-5.0.0.tgz",
+                    "integrity": "sha1-J17PDX/+Bcd+ZOfIbkzZS/DhIoo=",
+                    "dependencies": {
+                        "camelcase": {
+                            "version": "3.0.0",
+                            "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-3.0.0.tgz",
+                            "integrity": "sha1-MvxLn82vhF/N9+c7uXysImHwqwo="
+                        }
+                    }
+                }
+            }
+        },
+        "oauth-sign": {
+            "version": "0.8.2",
+            "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.8.2.tgz",
+            "integrity": "sha1-Rqarfwrq2N6unsBWV4C31O/rnUM="
+        },
+        "once": {
+            "version": "1.4.0",
+            "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+            "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E="
+        },
+        "only-shallow": {
+            "version": "1.2.0",
+            "resolved": "https://registry.npmjs.org/only-shallow/-/only-shallow-1.2.0.tgz",
+            "integrity": "sha1-cc7O26kyS8BRiu8Q7AgNMkncJGU="
+        },
+        "opener": {
+            "version": "1.4.3",
+            "resolved": "https://registry.npmjs.org/opener/-/opener-1.4.3.tgz",
+            "integrity": "sha1-XG2ixdflgx6P+jlklQ+NZnSskLg="
+        },
+        "os-homedir": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.1.tgz",
+            "integrity": "sha1-DWK99EuRb9O73PLKsZGUj7CU8Ac="
+        },
+        "own-or": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/own-or/-/own-or-1.0.0.tgz",
+            "integrity": "sha1-Tod/vtqaLsgAD7wLyuOWRe6L+Nw="
+        },
+        "own-or-env": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/own-or-env/-/own-or-env-1.0.0.tgz",
+            "integrity": "sha1-nvkg/IHi5jz1nUEQElg2jPT8pPs="
+        },
+        "path-is-absolute": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+            "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18="
+        },
+        "pinkie": {
+            "version": "2.0.4",
+            "resolved": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz",
+            "integrity": "sha1-clVrgM+g1IqXToDnckjoDtT3+HA="
+        },
+        "pinkie-promise": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
+            "integrity": "sha1-ITXW36ejWMBprJsXh3YogihFD/o="
+        },
+        "process-nextick-args": {
+            "version": "1.0.7",
+            "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz",
+            "integrity": "sha1-FQ4gt1ZZCtP5EJPyWk8q2L/zC6M="
+        },
+        "pseudomap": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/pseudomap/-/pseudomap-1.0.2.tgz",
+            "integrity": "sha1-8FKijacOYYkX7wqKw0wa5aaChrM="
+        },
+        "punycode": {
+            "version": "1.4.1",
+            "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz",
+            "integrity": "sha1-wNWmOycYgArY4esPpSachN1BhF4="
+        },
+        "qs": {
+            "version": "6.3.2",
+            "resolved": "https://registry.npmjs.org/qs/-/qs-6.3.2.tgz",
+            "integrity": "sha1-51vV9uJoEioqDgvaYwslUMFmUCw="
+        },
+        "readable-stream": {
+            "version": "2.2.11",
+            "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.2.11.tgz",
+            "integrity": "sha512-h+8+r3MKEhkiVrwdKL8aWs1oc1VvBu33ueshOvS26RsZQ3Amhx/oO3TKe4lApSV9ueY6as8EAh7mtuFjdlhg9Q=="
+        },
+        "request": {
+            "version": "2.79.0",
+            "resolved": "https://registry.npmjs.org/request/-/request-2.79.0.tgz",
+            "integrity": "sha1-Tf5b9r6LjNw3/Pk+BLZVd3InEN4="
+        },
+        "safe-buffer": {
+            "version": "5.0.1",
+            "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.0.1.tgz",
+            "integrity": "sha1-0mPKVGls2KMGtcplUekt5XkY++c="
+        },
+        "signal-exit": {
+            "version": "3.0.2",
+            "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz",
+            "integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0="
+        },
+        "sntp": {
+            "version": "1.0.9",
+            "resolved": "https://registry.npmjs.org/sntp/-/sntp-1.0.9.tgz",
+            "integrity": "sha1-ZUEYTMkK7qbG57NeJlkIJEPGYZg="
+        },
+        "source-map": {
+            "version": "0.5.6",
+            "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.6.tgz",
+            "integrity": "sha1-dc449SvwczxafwwRjYEzSiu19BI="
+        },
+        "source-map-support": {
+            "version": "0.4.15",
+            "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.4.15.tgz",
+            "integrity": "sha1-AyAt9lwG0r2MfsI2KhkwVv7407E="
+        },
+        "sprintf-js": {
+            "version": "1.0.3",
+            "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
+            "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw="
+        },
+        "sshpk": {
+            "version": "1.13.1",
+            "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.13.1.tgz",
+            "integrity": "sha1-US322mKHFEMW3EwY/hzx2UBzm+M=",
+            "dependencies": {
+                "assert-plus": {
+                    "version": "1.0.0",
+                    "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
+                    "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU="
+                }
+            }
+        },
+        "stack-utils": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/stack-utils/-/stack-utils-1.0.1.tgz",
+            "integrity": "sha1-1PM6tU6OOHeLDKXP07OvsS22hiA="
+        },
+        "string_decoder": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.2.tgz",
+            "integrity": "sha1-sp4fThEl+pehA4K4pTNze3SR4Xk="
+        },
+        "stringstream": {
+            "version": "0.0.5",
+            "resolved": "https://registry.npmjs.org/stringstream/-/stringstream-0.0.5.tgz",
+            "integrity": "sha1-TkhM1N5aC7vuGORjB3EKioFiGHg="
+        },
+        "strip-ansi": {
+            "version": "3.0.1",
+            "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+            "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8="
+        },
+        "supports-color": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
+            "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc="
+        },
+        "tap": {
+            "version": "10.3.3",
+            "resolved": "https://registry.npmjs.org/tap/-/tap-10.3.3.tgz",
+            "integrity": "sha512-ELPgkGOlrS4fj2iX7CFg9oJ4kGcA8xYurvtJhRN+O/CI52X+vSpHdahjx71ABX3Y774XcPKouU+DYB9lqrR2uQ=="
+        },
+        "tap-mocha-reporter": {
+            "version": "3.0.3",
+            "resolved": "https://registry.npmjs.org/tap-mocha-reporter/-/tap-mocha-reporter-3.0.3.tgz",
+            "integrity": "sha1-5ZF/rT2acJV/m3xzbnk764fX2vE="
+        },
+        "tap-parser": {
+            "version": "5.4.0",
+            "resolved": "https://registry.npmjs.org/tap-parser/-/tap-parser-5.4.0.tgz",
+            "integrity": "sha512-BIsIaGqv7uTQgTW1KLTMNPSEQf4zDDPgYOBRdgOfuB+JFOLRBfEu6cLa/KvMvmqggu1FKXDfitjLwsq4827RvA=="
+        },
+        "tmatch": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/tmatch/-/tmatch-3.0.0.tgz",
+            "integrity": "sha1-fSBx3tu8WH8ZSs2jBnvQdHtnCZE="
+        },
+        "tough-cookie": {
+            "version": "2.3.2",
+            "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.3.2.tgz",
+            "integrity": "sha1-8IH3bkyFcg5sN6X6ztc3FQ2EByo="
+        },
+        "trivial-deferred": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/trivial-deferred/-/trivial-deferred-1.0.1.tgz",
+            "integrity": "sha1-N21NKdlR1jaKb3oK6FwvTV4GWPM="
+        },
+        "tunnel-agent": {
+            "version": "0.4.3",
+            "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.4.3.tgz",
+            "integrity": "sha1-Y3PbdpCf5XDgjXNYM2Xtgop07us="
+        },
+        "tweetnacl": {
+            "version": "0.14.5",
+            "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz",
+            "integrity": "sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q=",
+            "optional": true
+        },
+        "unicode-length": {
+            "version": "1.0.3",
+            "resolved": "https://registry.npmjs.org/unicode-length/-/unicode-length-1.0.3.tgz",
+            "integrity": "sha1-Wtp6f+1RhBpBijKM8UlHisg1irs="
+        },
+        "util-deprecate": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+            "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8="
+        },
+        "uuid": {
+            "version": "3.0.1",
+            "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.0.1.tgz",
+            "integrity": "sha1-ZUS7ot/ajBzxfmKaOjBeK7H+5sE="
+        },
+        "verror": {
+            "version": "1.3.6",
+            "resolved": "https://registry.npmjs.org/verror/-/verror-1.3.6.tgz",
+            "integrity": "sha1-z/XfEpRtKX0rqu+qJoniW+AcAFw="
+        },
+        "which": {
+            "version": "1.2.14",
+            "resolved": "https://registry.npmjs.org/which/-/which-1.2.14.tgz",
+            "integrity": "sha1-mofEN48D6CfOyvGs31bHNsAcFOU=",
+            "dependencies": {
+                "isexe": {
+                    "version": "2.0.0",
+                    "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+                    "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA="
+                }
+            }
+        },
+        "wrappy": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+            "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
+        },
+        "xtend": {
+            "version": "4.0.1",
+            "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz",
+            "integrity": "sha1-pcbVMr5lbiPbgg77lDofBJmNY68="
+        },
+        "yallist": {
+            "version": "2.1.2",
+            "resolved": "https://registry.npmjs.org/yallist/-/yallist-2.1.2.tgz",
+            "integrity": "sha1-HBH5IY8HYImkfdUS+TxmmaaoHVI="
+        },
+        "yapool": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/yapool/-/yapool-1.0.0.tgz",
+            "integrity": "sha1-9pPymjFbUNmp2iZGp6ZkXJaYW2o="
+        }
+    }
+}

--- a/package.json
+++ b/package.json
@@ -1,20 +1,32 @@
 {
     "name": "voltjs",
+    "version": "2.0.0",
     "description": "VoltDB binary driver",
-    "version": "1.1.0",
+    "keywords": [
+        "voltdb",
+        "client",
+        "driver",
+        "binary driver"
+    ],
+    "bugs": {
+        "url": "https://github.com/VoltDB/voltdb-client-nodejs/issues",
+        "email": "support@voltdb.com"
+    },
+    "license": "MIT",
     "author": "VoltDB",
     "engines": {
-        "node": ">= 0.6.0"
+        "node": ">= 6.11.0"
     },
     "repository": {
         "type": "git",
         "url": "https://github.com/VoltDB/voltdb-client-nodejs.git"
     },
-
     "dependencies": {
-        "bignumber": "latest",
-        "ctype": "latest",
-        "cli": "latest",
-        "nodeunit": "latest"
+        "bignumber": "^1.1.0",
+        "ctype": "^0.5.0",
+        "cli": "^1.0.0"
+    },
+    "devDependencies": {
+        "nodeunit": "^0.11.0"
     }
 }

--- a/tools/testdb/ddl.sql
+++ b/tools/testdb/ddl.sql
@@ -16,3 +16,9 @@ CREATE TABLE typetest
     	test_id
   	)
 );
+
+PARTITION TABLE typetest ON COLUMN test_id;
+
+CREATE PROCEDURE FROM CLASS com.voltdb.test.typetest.proc.Insert;
+
+CREATE PROCEDURE FROM CLASS com.voltdb.test.typetest.proc.InitTestType;

--- a/tools/testdb/run.sh
+++ b/tools/testdb/run.sh
@@ -29,6 +29,7 @@ function srccompile() {
     javac -classpath $CLASSPATH -d obj \
         -sourcepath ./src \
         ./src/com/voltdb/test/typetest/proc/*.java
+    jar  cvf  $APPNAME.jar -C obj .
     # stop if compilation fails
     if [ $? != 0 ]; then exit; fi
 }
@@ -36,7 +37,7 @@ function srccompile() {
 # build an application catalog
 function catalog() {
     srccompile
-    $VOLTCOMPILER obj project.xml $APPNAME.jar
+    
     # stop if compilation fails
     if [ $? != 0 ]; then exit; fi
 }
@@ -46,8 +47,8 @@ function server() {
     # if a catalog doesn't exist, build one
     if [ ! -f $APPNAME.jar ]; then catalog; fi
     # run the server
-    $VOLTDB create catalog $APPNAME.jar deployment deployment.xml \
-        license $LICENSE leader $LEADER
+    $VOLTDB init -C deployment.xml -f -j $APPNAME.jar -s ddl.sql
+    $VOLTDB start
 }
 
 # Run the target passed as the first arg on the command line


### PR DESCRIPTION
Update required node and library versions, fixes to support Volt 7.5, ensure tests and examples remain functional and some hygiene changes to package.json

Have bumped version to 2.0 due to minimum node version increase - probably need to bundle some more fixes before cutting a 2.0 release though.